### PR TITLE
Fix Homepage public ingress migration

### DIFF
--- a/apps/homelab/homepage/generated/internal/services.yaml
+++ b/apps/homelab/homepage/generated/internal/services.yaml
@@ -57,9 +57,17 @@
         namespace: pihole-system
         app: pihole
 - Internal:
+    - Alertmanager:
+        icon: mdi-web
+        href: https://alertmanager.internal.dtavana.dev
+        description: nginx-internal ingress
     - Govee2mqtt:
         icon: mdi-web
         href: https://govee2mqtt.internal.dtavana.dev
+        description: nginx-internal ingress
+    - Grafana:
+        icon: mdi-web
+        href: https://grafana.internal.dtavana.dev
         description: nginx-internal ingress
     - Mqtt:
         icon: mdi-web
@@ -70,4 +78,8 @@
     - Mqttx:
         icon: mdi-web
         href: https://mqttx.internal.dtavana.dev
+        description: nginx-internal ingress
+    - Prometheus:
+        icon: mdi-web
+        href: https://prometheus.internal.dtavana.dev
         description: nginx-internal ingress

--- a/apps/homelab/homepage/ingress.yaml
+++ b/apps/homelab/homepage/ingress.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: homepage-public
+  name: homepage
   namespace: homepage-system
   labels:
     app.kubernetes.io/name: homepage

--- a/scripts/generate-homepage-config.rb
+++ b/scripts/generate-homepage-config.rb
@@ -214,4 +214,6 @@ services = ingresses
   File.write(File.join(dir, "custom.js"), "")
 end
 
+system("yamlfmt", "-conf", ".yamlfmt.yaml", OUTPUT_ROOT, chdir: ROOT) if system("which", "yamlfmt", out: File::NULL)
+
 warn "Wrote Homepage config to #{OUTPUT_ROOT}"


### PR DESCRIPTION
## Summary
- keep the public Homepage ingress named `homepage` so Flux updates the existing object instead of creating a duplicate host/path
- - make the Homepage generator format its output with the repo yamlfmt config
- - refresh generated Homepage config from current main
## Verification
- `kubectl apply --dry-run=server -k apps/homelab/homepage`
- - pre-commit hooks during commit
- 