### PR TITLE
Remove stale adminer health check

### DIFF
--- a/clusters/homelab/flux-system/apps-kustomization.yaml
+++ b/clusters/homelab/flux-system/apps-kustomization.yaml
@@ -16,10 +16,6 @@ spec:
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease
-      name: adminer
-      namespace: flux-system
-    - apiVersion: helm.toolkit.fluxcd.io/v2
-      kind: HelmRelease
       name: bambuddy
       namespace: flux-system
     - apiVersion: helm.toolkit.fluxcd.io/v2


### PR DESCRIPTION
Removes the stale `adminer` HelmRelease health check from the Flux apps Kustomization. `adminer` is not included in `apps/homelab/kustomization.yaml`, so Flux was waiting on a resource it no longer manages.

Verification: `kubectl kustomize clusters/homelab/flux-system` and pre-commit hooks.
