### PR TITLE
Add TLS for Homepage ingresses

### DIFF
--- a/apps/homelab/homepage/ingress-internal.yaml
+++ b/apps/homelab/homepage/ingress-internal.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     app.kubernetes.io/name: homepage
     app.kubernetes.io/instance: internal
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
 spec:
   ingressClassName: nginx-internal
   rules:
@@ -29,3 +31,8 @@ spec:
                 name: homepage-internal
                 port:
                   name: http
+  tls:
+    - secretName: homepage-internal-tls
+      hosts:
+        - homepage.internal.dtavana.dev
+        - homepage.dtavana.dev

--- a/apps/homelab/homepage/ingress.yaml
+++ b/apps/homelab/homepage/ingress.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     app.kubernetes.io/name: homepage
     app.kubernetes.io/instance: public
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
 spec:
   ingressClassName: nginx
   rules:
@@ -19,3 +21,7 @@ spec:
                 name: homepage-public
                 port:
                   name: http
+  tls:
+    - secretName: homepage-tls
+      hosts:
+        - homepage.dtavana.dev


### PR DESCRIPTION
## Summary
- add cert-manager TLS annotations to the public and internal Homepage ingresses
- - issue separate TLS secrets for the public nginx and internal nginx paths
- - include homepage.dtavana.dev on the internal cert because Pi-hole resolves that host to the internal ingress on LAN
## Validation
- kubectl kustomize apps/homelab/homepage
- - kubectl apply --dry-run=server -k apps/homelab/homepage