### PR TITLE
Keep Homepage public ingress HTTP-only

### DIFF
--- a/apps/homelab/homepage/ingress.yaml
+++ b/apps/homelab/homepage/ingress.yaml
@@ -6,8 +6,6 @@ metadata:
   labels:
     app.kubernetes.io/name: homepage
     app.kubernetes.io/instance: public
-  annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-production
 spec:
   ingressClassName: nginx
   rules:
@@ -21,7 +19,3 @@ spec:
                 name: homepage-public
                 port:
                   name: http
-  tls:
-    - secretName: homepage-tls
-      hosts:
-        - homepage.dtavana.dev


### PR DESCRIPTION
## Summary
- remove cert-manager TLS from the public Homepage nginx ingress
- - leave TLS on the internal Homepage ingress for LAN access to homepage.internal.dtavana.dev and Pi-hole-overridden homepage.dtavana.dev
- - keep Pangolin as the TLS owner for the external public route
## Validation
- kubectl kustomize apps/homelab/homepage
- - kubectl apply --dry-run=server -k apps/homelab/homepage