### PR TITLE
[codex] Fix Newt PVC rollout strategy

### DIFF
--- a/infrastructure/base/pangolin/helmrelease.yaml
+++ b/infrastructure/base/pangolin/helmrelease.yaml
@@ -17,6 +17,20 @@ spec:
   valuesFrom:
     - kind: ConfigMap
       name: newt-values
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: newt-system-pangolin-newt-newt-main-tunnel
+            patch: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: newt-system-pangolin-newt-newt-main-tunnel
+              spec:
+                strategy:
+                  type: Recreate
   install:
     remediation:
       retries: 3


### PR DESCRIPTION
## Summary
- patch the rendered Newt Deployment to use Recreate strategy via Flux Helm post-renderer
- prevent RollingUpdate from starting a replacement pod while the old pod still holds the RWO Longhorn config PVC

## Root cause
The Bambuddy route removal changed the Newt blueprint checksum, which triggered a Deployment rollout. Newt uses a persistent RWO Longhorn PVC for /var/lib/newt, and the default RollingUpdate strategy created the new pod before deleting the old one. That caused Longhorn Multi-Attach and stale staging-path mount errors, so Helm waited until its 5 minute timeout and marked the upgrade failed.

## Validation
- kubectl kustomize infrastructure/homelab
- commit hooks: Format YAML, Lint YAML