### PR TITLE
Improve Home Assistant node failover

### DIFF
--- a/apps/homelab/home-assistant/values.yaml
+++ b/apps/homelab/home-assistant/values.yaml
@@ -21,6 +21,15 @@ configuration:
 env:
   - name: TZ
     value: "America/New_York"
+tolerations:
+  - key: node.kubernetes.io/not-ready
+    operator: Exists
+    effect: NoExecute
+    tolerationSeconds: 30
+  - key: node.kubernetes.io/unreachable
+    operator: Exists
+    effect: NoExecute
+    tolerationSeconds: 30
 initContainers:
   - name: install-hacs
     image: alpine:latest

--- a/infrastructure/homelab/longhorn/values.yaml
+++ b/infrastructure/homelab/longhorn/values.yaml
@@ -2,6 +2,7 @@ defaultSettings:
   defaultDataPath: "/var/lib/longhorn/"
   defaultDataLocality: "disabled"
   defaultReplicaCount: '{"v1":"3","v2":"3"}'
+  nodeDownPodDeletionPolicy: "delete-both-statefulset-and-deployment-pod"
   replicaSoftAntiAffinity: false
   replicaAutoBalance: "disabled"
   storageMinimalAvailablePercentage: 25


### PR DESCRIPTION
## Summary
- shorten Home Assistant pod toleration for not-ready/unreachable nodes to 30 seconds
- configure Longhorn to delete stale StatefulSet/Deployment pods when a node is down

## Validation
- kubectl kustomize apps/homelab/home-assistant
- kubectl kustomize infrastructure/homelab/longhorn
- pre-commit hooks during git commit: Generate Homepage config, Generate Pangolin blueprint values, Format YAML, Lint YAML